### PR TITLE
Add schema-markdown tests

### DIFF
--- a/schema-markdown.test.js
+++ b/schema-markdown.test.js
@@ -1,0 +1,116 @@
+const { jsonSchemaToMarkdown, generateFullMarkdown } = require('./schema-markdown');
+
+describe('JSON Schema to Markdown Converter', () => {
+    const schemaRegistry = {};
+
+    beforeEach(() => {
+        // テスト用のスキーマを登録
+        schemaRegistry['customer.json'] = {
+            $id: 'customer.json',
+            type: 'object',
+            properties: {
+                id: { type: 'integer', description: 'Customer ID', format: 'id' },
+                name: { type: 'string', description: 'Customer name', minLength: 1, maxLength: 100 },
+                email: { type: 'string', description: 'Customer email', format: 'email' },
+                address: { $ref: 'address.json' }
+            },
+            required: ['id', 'name', 'email']
+        };
+
+        schemaRegistry['address.json'] = {
+            $id: 'address.json',
+            type: 'object',
+            properties: {
+                street: { type: 'string', description: 'Street address' },
+                city: { type: 'string', description: 'City name' },
+                zipCode: { type: 'string', description: 'Zip code', pattern: '^\\d{5}$' }
+            },
+            required: ['street', 'city']
+        };
+
+        global.schemaRegistry = schemaRegistry;
+    });
+
+    test('jsonSchemaToMarkdown should generate correct markdown for a single schema', () => {
+        const expectedMarkdown = `## customer
+
+| Property | Type    | Description | Required | Constraints |
+|----------|---------|-------------|----------|-------------|
+| id | integer | Customer ID | Yes | format: id |
+| name | string | Customer name | Yes | minLength: 1, maxLength: 100 |
+| email | string | Customer email | Yes | format: email |
+| address | object | Embedded: [address](#address) | No | |`;
+
+        const result = jsonSchemaToMarkdown(schemaRegistry['customer.json'], '');
+        expect(result.trim()).toBe(expectedMarkdown);
+    });
+
+    test('generateFullMarkdown should generate correct markdown for multiple schemas', () => {
+        const expectedMarkdown = `## customer
+
+| Property | Type    | Description | Required | Constraints |
+|----------|---------|-------------|----------|-------------|
+| id | integer | Customer ID | Yes | format: id |
+| name | string | Customer name | Yes | minLength: 1, maxLength: 100 |
+| email | string | Customer email | Yes | format: email |
+| address | object | Embedded: [address](#address) | No | |
+
+
+## address
+
+| Property | Type    | Description | Required | Constraints |
+|----------|---------|-------------|----------|-------------|
+| street | string | Street address | Yes |  |
+| city | string | City name | Yes |  |
+| zipCode | string | Zip code | No | pattern: ^\\d{5}$ |`;
+
+        const result = generateFullMarkdown(Object.values(schemaRegistry), '');
+        expect(result.trim()).toBe(expectedMarkdown);
+    });
+
+    test('jsonSchemaToMarkdown should handle schemas without properties', () => {
+        const emptySchema = {
+            $id: 'empty.json',
+            type: 'object'
+        };
+
+        const expectedMarkdown = `## empty`;
+
+        const result = jsonSchemaToMarkdown(emptySchema, '');
+        expect(result.trim()).toBe(expectedMarkdown.trim());
+    });
+
+    test('generateFullMarkdown should handle circular references', () => {
+        schemaRegistry['circular1.json'] = {
+            $id: 'circular1.json',
+            type: 'object',
+            properties: {
+                ref2: { $ref: 'circular2.json' }
+            }
+        };
+
+        schemaRegistry['circular2.json'] = {
+            $id: 'circular2.json',
+            type: 'object',
+            properties: {
+                ref1: { $ref: 'circular1.json' }
+            }
+        };
+
+        const expectedMarkdown = `## circular1
+
+| Property | Type    | Description | Required | Constraints |
+|----------|---------|-------------|----------|-------------|
+| ref2 | object | Embedded: [circular2](#circular2) | No | |
+
+
+## circular2
+
+| Property | Type    | Description | Required | Constraints |
+|----------|---------|-------------|----------|-------------|
+| ref1 | object | Embedded: [circular1](#circular1) | No | |`;
+
+        const result = generateFullMarkdown([schemaRegistry['circular1.json'], schemaRegistry['circular2.json']], '');
+        expect(result.trim()).toBe(expectedMarkdown);
+    });
+});


### PR DESCRIPTION
Introduces tests for the schema-markdown conversion functions. The tests cover different possible scenarios including handling JSON schemas without properties and schemas with circular references. It also validates if the correct markdown is being generated from the input JSON schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to convert JSON schemas to Markdown format.
  - Added the ability to generate full Markdown documentation for schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->